### PR TITLE
Use blocking task queue and fix regex warnings

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -16,7 +16,7 @@ sys.modules['modules.generation_parameters_copypaste'] = sys.modules[__name__]  
 re_param_code = r'\s*(\w[\w \-/]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|$)'
 re_param = re.compile(re_param_code)
 re_imagesize = re.compile(r"^(\d+)x(\d+)$")
-re_hypernet_hash = re.compile("\(([0-9a-f]+)\)$")
+re_hypernet_hash = re.compile(r"\(([0-9a-f]+)\)$")
 type_of_gr_update = type(gr.update())
 
 

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -381,7 +381,7 @@ re_attention = re.compile(r"""
 re_break = re.compile(r"\s*\bBREAK\b\s*", re.S)
 
 def parse_prompt_attention(text):
-    """
+    r"""
     Parses a string with attention tokens and returns a list of pairs: text and its associated weight.
     Accepted tokens are:
       (abc) - increases attention to abc by a multiplier of 1.1

--- a/modules_forge/main_thread.py
+++ b/modules_forge/main_thread.py
@@ -3,15 +3,17 @@
 # By using one single thread to process all major calls, model moving is significantly faster.
 
 
-import time
-import traceback
+from __future__ import annotations
+
+import queue
 import threading
+import traceback
 
 
 lock = threading.Lock()
 last_id = 0
-waiting_list = []
-finished_list = []
+task_queue: queue.Queue[Task] = queue.Queue()
+task_dict: dict[int, Task] = {}
 
 
 class Task:
@@ -21,48 +23,40 @@ class Task:
         self.args = args
         self.kwargs = kwargs
         self.result = None
+        self.event = threading.Event()
 
     def work(self):
-        self.result = self.func(*self.args, **self.kwargs)
+        try:
+            self.result = self.func(*self.args, **self.kwargs)
+        except Exception as e:
+            traceback.print_exc()
+            print(e)
+        finally:
+            self.event.set()
 
 
 def loop():
-    global lock, last_id, waiting_list, finished_list
     while True:
-        time.sleep(0.01)
-        if len(waiting_list) > 0:
-            with lock:
-                task = waiting_list.pop(0)
-            try:
-                task.work()
-            except Exception as e:
-                traceback.print_exc()
-                print(e)
-            with lock:
-                finished_list.append(task)
+        task = task_queue.get()
+        task.work()
+        task_queue.task_done()
 
 
 def async_run(func, *args, **kwargs):
-    global lock, last_id, waiting_list, finished_list
+    global last_id
     with lock:
         last_id += 1
         new_task = Task(task_id=last_id, func=func, args=args, kwargs=kwargs)
-        waiting_list.append(new_task)
+        task_dict[new_task.task_id] = new_task
+    task_queue.put(new_task)
     return new_task.task_id
 
 
 def run_and_wait_result(func, *args, **kwargs):
-    global lock, last_id, waiting_list, finished_list
     current_id = async_run(func, *args, **kwargs)
-    while True:
-        time.sleep(0.01)
-        finished_task = None
-        for t in finished_list.copy():  # thread safe shallow copy without needing a lock
-            if t.task_id == current_id:
-                finished_task = t
-                break
-        if finished_task is not None:
-            with lock:
-                finished_list.remove(finished_task)
-            return finished_task.result
+    task = task_dict[current_id]
+    task.event.wait()
+    with lock:
+        task_dict.pop(current_id, None)
+    return task.result
 


### PR DESCRIPTION
## Summary
- refactor main thread task queue to block on `queue.Queue`
- fix invalid escape warnings in `infotext_utils` and `prompt_parser`

## Testing
- `python -m py_compile modules_forge/main_thread.py modules/infotext_utils.py modules/prompt_parser.py`
- `python -m pytest -k test_utils -q` *(fails: ModuleNotFoundError: numpy, torch)*

------
https://chatgpt.com/codex/tasks/task_e_68446e056c44832481eb22129dfaf1e4